### PR TITLE
Hold ksvc name in status.firstServiceName to fixed URL allocated

### DIFF
--- a/pkg/apis/sources/v1alpha1/dockerhubsource_types.go
+++ b/pkg/apis/sources/v1alpha1/dockerhubsource_types.go
@@ -83,6 +83,10 @@ type DockerHubSourceStatus struct {
 	// URL holds the information needed to connect this up to receive events.
 	// +optional
 	URL *apis.URL `json:"url,omitempty"`
+
+	// FirstServiceName holds the information of knative service name to recreate service when accidentally deleted.
+	// +optional
+	FirstServiceName string `json:"firstServiceName,omitempty"`
 }
 
 // GetStatus retrieves the status of the DockerHubSource. Implements the KRShaped interface.

--- a/pkg/reconciler/source/dockerhubsource.go
+++ b/pkg/reconciler/source/dockerhubsource.go
@@ -71,6 +71,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, src *v1alpha1.DockerHubS
 			return err
 		}
 		src.Status.AutoCallbackDisabled = src.Spec.DisableAutoCallback
+		src.Status.FirstServiceName = ksvc.GetName()
 		controller.GetEventRecorder(ctx).Eventf(src, corev1.EventTypeNormal, "ServiceCreated", "Created Service %q", ksvc.Name)
 	} else if err != nil {
 		src.Status.MarkNoEndpoint("ServiceUnavailable", "%v", err)
@@ -145,7 +146,12 @@ func (r *Reconciler) getOwnedService(_ context.Context, src *v1alpha1.DockerHubS
 }
 
 func (r *Reconciler) getExpectedService(ctx context.Context, src *v1alpha1.DockerHubSource) *v1.Service {
-	return resources.MakeService(r.getServiceArgs(ctx, src))
+	ksvc := resources.MakeService(r.getServiceArgs(ctx, src))
+	if firstName := src.Status.FirstServiceName; firstName != "" {
+		ksvc.ObjectMeta.SetGenerateName("")
+		ksvc.ObjectMeta.SetName(firstName)
+	}
+	return ksvc
 }
 
 func (r *Reconciler) getServiceArgs(ctx context.Context, src *v1alpha1.DockerHubSource) *resources.ServiceArgs {


### PR DESCRIPTION
The context is refereed in https://github.com/tom24d/eventing-dockerhub/pull/28#issuecomment-641877017 .