### PR TITLE
[release 0.17.1] do not use dev.knative as CloudEventType prefix

### DIFF
--- a/pkg/adapter/adapter_test.go
+++ b/pkg/adapter/adapter_test.go
@@ -32,6 +32,7 @@ const (
 	testCallbackPort            = "4320"
 	testAdapterPort             = "8765"
 	callbackServerWaitThreshold = 4
+	cloudEventType              = "tom24d.source.dockerhub.push"
 )
 
 var testTime, _ = cetypes.ParseTime("2018-04-05T17:31:00Z")
@@ -82,7 +83,7 @@ var testCases = []testCase{
 		httpMethod:             http.MethodPost,
 		eventType:              resources.DockerHubEventType,
 		cloudEventSendExpected: true,
-		wantCloudEventType:     "dev.knative.source.dockerhub.push",
+		wantCloudEventType:     cloudEventType,
 		wantCloudEventSubject:  testSubject,
 		wantCloudEventTime: func() time.Time {
 			var testCETime = time.Unix(testTime.Unix(), 0)
@@ -101,7 +102,7 @@ var testCases = []testCase{
 		httpMethod:             http.MethodPost,
 		eventType:              resources.DockerHubEventType,
 		cloudEventSendExpected: false,
-		wantCloudEventType:     "dev.knative.source.dockerhub.push",
+		wantCloudEventType:     cloudEventType,
 		wantCallbackExpected:   false,
 	},
 	{
@@ -127,7 +128,7 @@ var testCases = []testCase{
 		httpMethod:             http.MethodPost,
 		eventType:              resources.DockerHubEventType,
 		cloudEventSendExpected: false,
-		wantCloudEventType:     "dev.knative.source.dockerhub.push",
+		wantCloudEventType:     cloudEventType,
 		wantCallbackExpected:   false,
 	},
 	{
@@ -139,7 +140,7 @@ var testCases = []testCase{
 		httpMethod:             http.MethodPost,
 		eventType:              resources.DockerHubEventType,
 		cloudEventSendExpected: false,
-		wantCloudEventType:     "dev.knative.source.dockerhub.push",
+		wantCloudEventType:     cloudEventType,
 		wantCallbackExpected:   false,
 	},
 	{
@@ -156,7 +157,7 @@ var testCases = []testCase{
 		httpMethod:             http.MethodPost,
 		eventType:              resources.DockerHubEventType,
 		cloudEventSendExpected: false,
-		wantCloudEventType:     "dev.knative.source.dockerhub.push",
+		wantCloudEventType:     cloudEventType,
 		wantCallbackExpected:   false,
 	},
 	{
@@ -169,7 +170,7 @@ var testCases = []testCase{
 		httpMethod:             http.MethodPatch,
 		eventType:              resources.DockerHubEventType,
 		cloudEventSendExpected: false,
-		wantCloudEventType:     "dev.knative.source.dockerhub.push",
+		wantCloudEventType:     cloudEventType,
 		wantCallbackExpected:   false,
 	},
 }

--- a/pkg/apis/sources/v1alpha1/dockerhubsource_types.go
+++ b/pkg/apis/sources/v1alpha1/dockerhubsource_types.go
@@ -41,7 +41,7 @@ var (
 )
 
 const (
-	dockerHubEventTypePrefix   = "dev.knative.source.dockerhub"
+	dockerHubEventTypePrefix   = "tom24d.source.dockerhub" // TODO change this to dev.knative when the time comes.
 	dockerHubEventSourcePrefix = "https://hub.docker.com"
 )
 

--- a/pkg/apis/sources/v1alpha1/dockerhubsource_types_test.go
+++ b/pkg/apis/sources/v1alpha1/dockerhubsource_types_test.go
@@ -21,7 +21,7 @@ func TestDockerHubSource_GetGroupVersionKind(t *testing.T) {
 }
 
 func TestDockerHubCloudEventsEventType(t *testing.T) {
-	prefix := "dev.knative.source.dockerhub"
+	prefix := "tom24d.source.dockerhub"
 	eventType := "push"
 	want := fmt.Sprintf("%s.%s", prefix, eventType)
 


### PR DESCRIPTION
to avoid conflict with ones owned and maintained by knative community.
cherry-picked from #133 